### PR TITLE
refactor(SMR): allow SMR handle future trigger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = { version = "0.4", features = ["serde"] }
 creep = "0.1"
 derive_more = "0.15"
 futures-preview = { version = "0.3.0-alpha.19", features = [ "async-await" ] }
-futures-timer = "0.4"
+futures-timer = "1.0"
 hex = "0.4"
 log = "0.4"
 parking_lot = "0.9"

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,14 +31,6 @@ pub enum ConsensusError {
     #[display(fmt = "Precommit error {}", _0)]
     PrecommitErr(String),
     ///
-    #[display(fmt = "Self round is {}, vote round is {}", local, vote)]
-    RoundDiff {
-        ///
-        local: u64,
-        ///
-        vote: u64,
-    },
-    ///
     #[display(fmt = "Self check not pass {}", _0)]
     SelfCheckErr(String),
     ///
@@ -87,9 +79,6 @@ impl PartialEq for ConsensusError {
             | (PrevoteErr(_), PrevoteErr(_))
             | (PrecommitErr(_), PrecommitErr(_))
             | (SelfCheckErr(_), SelfCheckErr(_)) => true,
-            // If it is the following two types of errors, in the judgment, the error type need the
-            // same, and the error information need the same.
-            (RoundDiff { local: m, vote: n }, RoundDiff { local: p, vote: q }) => m == p && n == q,
             (Other(x), Other(y)) | (CorrectnessErr(x), CorrectnessErr(y)) => x == y,
             _ => false,
         }

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -86,7 +86,8 @@ impl SMR {
                 trigger_type: trigger.clone(),
                 source: TriggerSource::State,
                 hash: Hash::new(),
-                round: None,
+                lock_round: None,
+                round: 0u64,
                 epoch_id,
             })
             .map_err(|_| ConsensusError::TriggerSMRErr(trigger.to_string()))

--- a/src/smr/smr_types.rs
+++ b/src/smr/smr_types.rs
@@ -177,8 +177,10 @@ pub struct SMRTrigger {
     pub source: TriggerSource,
     /// SMR trigger hash, the meaning shown above.
     pub hash: Hash,
+    /// SMR trigger lock round that is only for proposal.
+    pub lock_round: Option<u64>,
     /// SMR trigger round, the meaning shown above.
-    pub round: Option<u64>,
+    pub round: u64,
     /// **NOTICE**: This field is only for timer to signed timer's epoch ID. Therefore, the SMR can
     /// filter out the outdated timers.
     pub epoch_id: u64,

--- a/src/smr/tests/mod.rs
+++ b/src/smr/tests/mod.rs
@@ -64,13 +64,15 @@ impl SMRTrigger {
         proposal_hash: Hash,
         t_type: TriggerType,
         lock_round: Option<u64>,
+        round: u64,
         epoch_id: u64,
     ) -> Self {
         SMRTrigger {
             trigger_type: t_type,
             source: TriggerSource::State,
             hash: proposal_hash,
-            round: lock_round,
+            lock_round,
+            round,
             epoch_id,
         }
     }

--- a/src/smr/tests/new_epoch_test.rs
+++ b/src/smr/tests/new_epoch_test.rs
@@ -12,7 +12,7 @@ async fn test_new_epoch() {
     // The output should be new round info.
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -33,7 +33,7 @@ async fn test_new_epoch() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash, Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -51,7 +51,7 @@ async fn test_new_epoch() {
     let lock = Lock::new(0u64, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -68,7 +68,7 @@ async fn test_new_epoch() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -85,7 +85,7 @@ async fn test_new_epoch() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -102,7 +102,7 @@ async fn test_new_epoch() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,
@@ -120,7 +120,7 @@ async fn test_new_epoch() {
     let lock = Lock::new(0u64, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash, Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      1u64,
             round:         0u64,

--- a/src/smr/tests/precommit_test.rs
+++ b/src/smr/tests/precommit_test.rs
@@ -15,7 +15,7 @@ async fn test_precommit_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::Commit(hash.clone()),
         None,
         Some((0, hash)),
@@ -27,7 +27,7 @@ async fn test_precommit_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      0u64,
             round:         1u64,
@@ -45,7 +45,7 @@ async fn test_precommit_trigger() {
     let lock = Lock::new(0, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::Commit(hash.clone()),
         None,
         Some((0, hash)),
@@ -61,7 +61,7 @@ async fn test_precommit_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, hash.clone(), Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      0u64,
             round:         1u64,
@@ -79,7 +79,7 @@ async fn test_precommit_trigger() {
     let lock = Lock::new(0, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, Hash::new(), Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::Commit(hash.clone()),
         Some(ConsensusError::SelfCheckErr("".to_string())),
         Some((0, hash)),
@@ -93,7 +93,7 @@ async fn test_precommit_trigger() {
     let hash_new = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, Hash::new(), Some(lock)),
-        SMRTrigger::new(hash_new.clone(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(hash_new.clone(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::Commit(hash_new.clone()),
         Some(ConsensusError::SelfCheckErr("".to_string())),
         Some((0, hash_new)),
@@ -105,7 +105,7 @@ async fn test_precommit_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      0u64,
@@ -121,7 +121,7 @@ async fn test_precommit_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::NewRoundInfo {
             epoch_id:      0u64,
             round:         1u64,
@@ -129,19 +129,6 @@ async fn test_precommit_trigger() {
             lock_proposal: None,
         },
         Some(ConsensusError::SelfCheckErr("".to_string())),
-        Some((0, hash)),
-    ));
-
-    // Test case 09:
-    //      the precommit round is not equal to self round.
-    // This is an incorrect situation, the process will return round diff err.
-    let hash = gen_hash();
-    let lock = Lock::new(0, hash.clone());
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(0, Step::Precommit, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(1), 0),
-        SMREvent::Commit(hash.clone()),
-        Some(ConsensusError::RoundDiff { local: 0, vote: 1 }),
         Some((0, hash)),
     ));
 
@@ -167,14 +154,14 @@ async fn test_precommit_trigger() {
     let lock = Lock::new(0, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, hash.clone(), Some(lock)),
-        SMRTrigger::new(gen_hash(), TriggerType::PrecommitQC, Some(0), 0),
+        SMRTrigger::new(gen_hash(), TriggerType::PrecommitQC, None, 0, 0),
         SMREvent::Commit(hash.clone()),
         Some(ConsensusError::CorrectnessErr("Fork".to_string())),
         Some((0, hash)),
     ));
 
     for case in test_cases.into_iter() {
-        println!("Precommit test {}/11", index);
+        println!("Precommit test {}/9", index);
         index += 1;
         trigger_test(
             case.base,

--- a/src/smr/tests/prevote_test.rs
+++ b/src/smr/tests/prevote_test.rs
@@ -15,7 +15,7 @@ async fn test_prevote_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, None, 0, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      0u64,
@@ -31,7 +31,7 @@ async fn test_prevote_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, None, 0, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      0u64,
@@ -52,7 +52,7 @@ async fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash, TriggerType::PrevoteQC, None, 1u64, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -73,7 +73,7 @@ async fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, Hash::new(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash, TriggerType::PrevoteQC, None, 1, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -89,7 +89,7 @@ async fn test_prevote_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(Hash::new(), TriggerType::PrevoteQC, None, 1, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -106,7 +106,7 @@ async fn test_prevote_trigger() {
     let vote_hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), None),
-        SMRTrigger::new(vote_hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(vote_hash.clone(), TriggerType::PrevoteQC, None, 1, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -124,7 +124,7 @@ async fn test_prevote_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, None, 1, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -142,7 +142,7 @@ async fn test_prevote_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, None, 1, 0),
         SMREvent::PrecommitVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -168,24 +168,8 @@ async fn test_prevote_trigger() {
     //     None,
     // ));
 
-    // Test case 10:
-    //      the prevote round is not equal to self round.
-    // This is an incorrect situation, the process will return round diff err.
-    let hash = gen_hash();
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(1, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(2), 0),
-        SMREvent::PrecommitVote {
-            epoch_id:   0u64,
-            round:      1u64,
-            epoch_hash: Hash::new(),
-        },
-        Some(ConsensusError::RoundDiff { local: 1, vote: 2 }),
-        None,
-    ));
-
     for case in test_cases.into_iter() {
-        println!("Prevote test {}/10", index);
+        println!("Prevote test {}/8", index);
         index += 1;
         trigger_test(
             case.base,

--- a/src/smr/tests/proposal_test.rs
+++ b/src/smr/tests/proposal_test.rs
@@ -16,7 +16,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      0u64,
@@ -33,7 +33,7 @@ async fn test_proposal_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      0u64,
@@ -50,7 +50,7 @@ async fn test_proposal_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -67,7 +67,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -84,7 +84,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -101,7 +101,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -118,7 +118,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(Hash::new(), TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -135,7 +135,7 @@ async fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(Hash::new(), TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -154,7 +154,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -173,7 +173,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -192,7 +192,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -211,7 +211,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash, Some(lock)),
-        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, None, 0),
+        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -230,7 +230,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash, TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -249,7 +249,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, None, 0),
+        SMRTrigger::new(hash, TriggerType::Proposal, None, 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -268,7 +268,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 1, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      1u64,
@@ -288,7 +288,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 0),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 2, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      2u64,
@@ -308,7 +308,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(3, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(2), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(2), 3, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      3u64,
@@ -327,7 +327,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, Some(1), 0),
+        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, Some(1), 2, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      2u64,
@@ -349,7 +349,7 @@ async fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(1), 0),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(1), 2, 0),
         SMREvent::PrevoteVote {
             epoch_id:   0u64,
             round:      2u64,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -354,10 +354,11 @@ where
 
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
-            source:       TriggerSource::State,
-            hash:         hash.clone(),
-            round:        lock_round,
-            epoch_id:     self.epoch_id,
+            source: TriggerSource::State,
+            hash: hash.clone(),
+            round: self.round,
+            epoch_id: self.epoch_id,
+            lock_round,
         })?;
 
         info!(
@@ -491,10 +492,11 @@ where
 
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
-            source:       TriggerSource::State,
-            hash:         hash.clone(),
-            round:        lock_round,
-            epoch_id:     self.epoch_id,
+            source: TriggerSource::State,
+            hash: hash.clone(),
+            round: self.round,
+            epoch_id: self.epoch_id,
+            lock_round,
         })?;
 
         info!(
@@ -764,7 +766,8 @@ where
             trigger_type: vote_type.clone().into(),
             source:       TriggerSource::State,
             hash:         epoch_hash,
-            round:        Some(round),
+            lock_round:   None,
+            round:        self.round,
             epoch_id:     self.epoch_id,
         })?;
 
@@ -894,7 +897,8 @@ where
             trigger_type: qc_type.clone().into(),
             source:       TriggerSource::State,
             hash:         epoch_hash,
-            round:        Some(round),
+            lock_round:   None,
+            round:        self.round,
             epoch_id:     self.epoch_id,
         })?;
 
@@ -932,7 +936,8 @@ where
                     trigger_type: qc.vote_type.clone().into(),
                     source:       TriggerSource::State,
                     hash:         epoch_hash,
-                    round:        Some(self.round),
+                    lock_round:   None,
+                    round:        self.round,
                     epoch_id:     self.epoch_id,
                 })?;
 
@@ -966,7 +971,8 @@ where
                 trigger_type: vote_type.clone().into(),
                 source:       TriggerSource::State,
                 hash:         epoch_hash,
-                round:        Some(self.round),
+                lock_round:   None,
+                round:        self.round,
                 epoch_id:     self.epoch_id,
             })?;
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -644,11 +644,10 @@ where
         if self.next_proposer(status.epoch_id)?
             && Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval)
         {
-            Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
-                .await
-                .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
+            let dur =
+                self.epoch_start + Duration::from_millis(self.epoch_interval) - Instant::now();
+            Delay::new(dur).await;
         }
-
         self.goto_new_epoch(ctx, status, get_auth_flag).await?;
         Ok(())
     }
@@ -1377,7 +1376,7 @@ where
         });
 
         runtime::spawn(async move {
-            let _ = Delay::new(Duration::from_millis(5000)).await;
+            Delay::new(Duration::from_millis(5000)).await;
             if let Err(e) = new_tx.unbounded_send(CHECK_EPOCH_FAILED) {
                 error!(
                     "Overlord: state send check epoch flag failed, epoch ID {}, round {}, error {:?}",


### PR DESCRIPTION
This PR does:
* allow SMR handle triggers in future rounds 
* remove some outdated unit tests