### PR TITLE
refactor(api): crypto trait

### DIFF
--- a/examples/salon.rs
+++ b/examples/salon.rs
@@ -99,15 +99,17 @@ impl Crypto for MockCrypto {
 
     fn verify_signature(
         &self,
-        signature: Bytes,
+        _signature: Bytes,
         _hash: Bytes,
-    ) -> Result<Bytes, Box<dyn Error + Send>> {
-        Ok(signature)
+        _voter: Bytes,
+    ) -> Result<(), Box<dyn Error + Send>> {
+        Ok(())
     }
 
     fn verify_aggregated_signature(
         &self,
         _aggregated_signature: AggregatedSignature,
+        _voters: Vec<Bytes>,
     ) -> Result<(), Box<dyn Error + Send>> {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,12 +127,14 @@ pub trait Crypto: Send {
         &self,
         signature: Signature,
         hash: Hash,
-    ) -> Result<Address, Box<dyn Error + Send>>;
+        voter: Address,
+    ) -> Result<(), Box<dyn Error + Send>>;
 
     /// Verify an aggregated signature.
     fn verify_aggregated_signature(
         &self,
         aggregate_signature: AggregatedSignature,
+        voters: Vec<Address>,
     ) -> Result<(), Box<dyn Error + Send>>;
 }
 

--- a/src/state/tests/test_utils.rs
+++ b/src/state/tests/test_utils.rs
@@ -130,10 +130,11 @@ impl Crypto for BlsCrypto {
 
     fn verify_signature(
         &self,
-        signature: Signature,
+        _signature: Signature,
         _hash: Hash,
-    ) -> Result<Address, Box<dyn Error + Send>> {
-        Ok(signature)
+        _voter: Address,
+    ) -> Result<(), Box<dyn Error + Send>> {
+        Ok(())
     }
 
     fn aggregate_signatures(
@@ -149,6 +150,7 @@ impl Crypto for BlsCrypto {
     fn verify_aggregated_signature(
         &self,
         _aggregate_signature: AggregatedSignature,
+        _voters: Vec<Address>,
     ) -> Result<(), Box<dyn Error + Send>> {
         Ok(())
     }

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -140,8 +140,9 @@ impl Crypto for BlsCrypto {
         &self,
         _signature: Signature,
         _hash: Hash,
-    ) -> Result<Address, Box<dyn Error + Send>> {
-        Ok(self.0.clone())
+        _voter: Address,
+    ) -> Result<(), Box<dyn Error + Send>> {
+        Ok(())
     }
 
     fn aggregate_signatures(
@@ -155,6 +156,7 @@ impl Crypto for BlsCrypto {
     fn verify_aggregated_signature(
         &self,
         _aggregate_signature: AggregatedSignature,
+        _voters: Vec<Address>,
     ) -> Result<(), Box<dyn Error + Send>> {
         Ok(())
     }


### PR DESCRIPTION
This PR does:
refactor crypto trait‘s argument to suit aggregated signature:
* add `voter: Address` argument for `verify_signature()` function
* add `voters: Vec<Address>` argument for `verify_aggregated_signature()` function