### PR TITLE
fix(SMR): self check error after prevote timeout

### DIFF
--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -237,8 +237,10 @@ impl StateMachine {
             let round = if let Some(lock) = &self.lock {
                 Some(lock.round)
             } else {
+                self.epoch_hash = Hash::new();
                 None
             };
+
             self.throw_event(SMREvent::PrecommitVote {
                 epoch_id:   self.epoch_id,
                 round:      self.round,


### PR DESCRIPTION
This PR does:
* fix self check error after prevote timeout
When self is without lock, and prevote timeout, set `self.epoch_hash = Hash::new()`.