### PR TITLE
refactor: overlord broadcast empty vote and qc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = { version = "0.5", features = ["serde"] }
 creep = "0.2"
 derive_more = "0.99"
 futures = { version = "0.3", features = [ "async-await" ] }
-futures-timer = "2.0"
+futures-timer = "3.0"
 hex = "0.4"
 log = "0.4"
 moodyblues-sdk = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand_pcg = "0.2"
 rlp = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["macros", "rt-core"]}
+tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"]}
 
 [dev-dependencies]
 bincode = "1.2"

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -459,7 +459,7 @@ impl StateMachine {
         debug!("Overlord: SMR do self check");
 
         // Lock hash must be same as proposal hash, if has.
-        if self.height == 0
+        if self.round == 0
             && self.lock.is_some()
             && self.lock.clone().unwrap().hash != self.block_hash
         {

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -249,8 +249,6 @@ impl StateMachine {
             })?;
             self.goto_step(Step::Precommit);
             return Ok(());
-        } else if prevote_hash.is_empty() {
-            return Err(ConsensusError::PrevoteErr("Empty qc".to_string()));
         }
 
         // A prevote QC from timer which means prevote timeout can not lead to unlock. Therefore,
@@ -318,7 +316,8 @@ impl StateMachine {
             .clone()
             .map_or_else(|| (None, None), |lock| (Some(lock.round), Some(lock.hash)));
 
-        if source == TriggerSource::Timer {
+        if source == TriggerSource::Timer || precommit_hash.is_empty() {
+            self.round = precommit_round;
             self.throw_event(SMREvent::NewRoundInfo {
                 height: self.height,
                 round: self.round + 1,

--- a/src/smr/tests/precommit_test.rs
+++ b/src/smr/tests/precommit_test.rs
@@ -80,8 +80,13 @@ async fn test_precommit_trigger() {
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Precommit, Hash::new(), Some(lock)),
         SMRTrigger::new(Hash::new(), TriggerType::PrecommitQC, Some(0), 0),
-        SMREvent::Commit(hash.clone()),
-        Some(ConsensusError::PrecommitErr("Empty qc".to_string())),
+        SMREvent::NewRoundInfo {
+            height:        0u64,
+            round:         1u64,
+            lock_round:    Some(0),
+            lock_proposal: Some(hash.clone()),
+        },
+        None,
         Some((0, hash)),
     ));
 
@@ -129,8 +134,8 @@ async fn test_precommit_trigger() {
             lock_round:    None,
             lock_proposal: None,
         },
-        Some(ConsensusError::PrecommitErr("Empty qc".to_string())),
-        Some((0, hash)),
+        None,
+        None,
     ));
 
     // // Test case 10:

--- a/src/smr/tests/prevote_test.rs
+++ b/src/smr/tests/prevote_test.rs
@@ -54,15 +54,15 @@ async fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
         SMREvent::PrecommitVote {
             height:     0u64,
             round:      1u64,
-            block_hash: lock_hash.clone(),
+            block_hash: hash,
             lock_round: None,
         },
-        Some(ConsensusError::PrevoteErr("Empty qc".to_string())),
-        Some((0, lock_hash)),
+        None,
+        None,
     ));
 
     // Test case 04:
@@ -76,15 +76,15 @@ async fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, Hash::new(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
         SMREvent::PrecommitVote {
             height:     0u64,
             round:      1u64,
-            block_hash: lock_hash.clone(),
-            lock_round: None,
+            block_hash: hash.clone(),
+            lock_round: Some(1),
         },
-        Some(ConsensusError::SelfCheckErr("".to_string())),
-        Some((0, lock_hash)),
+        None,
+        Some((1, hash)),
     ));
 
     // Test case 05:

--- a/src/smr/tests/proposal_test.rs
+++ b/src/smr/tests/proposal_test.rs
@@ -221,16 +221,16 @@ async fn test_proposal_trigger() {
     let lock_hash = gen_hash();
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
-        InnerState::new(1, Step::Propose, hash, Some(lock)),
+        InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
         SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, None, 0),
         SMREvent::PrevoteVote {
             height:     0u64,
             round:      1u64,
-            block_hash: lock_hash,
-            lock_round: None,
+            block_hash: hash,
+            lock_round: Some(0),
         },
-        Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
+        Some((0, lock_hash)),
     ));
 
     // Test case 13:

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -875,7 +875,7 @@ where
 
         self.votes
             .insert_vote(signed_vote.get_hash(), signed_vote, voter);
-            
+
         if height > self.height {
             return Ok(());
         }
@@ -954,11 +954,6 @@ where
         _ctx: Context,
         aggregated_vote: AggregatedVote,
     ) -> ConsensusResult<()> {
-        if aggregated_vote.block_hash.is_empty() {
-            warn!("Overlord: state receive an empty aggregated vote");
-            return Ok(());
-        }
-
         let height = aggregated_vote.get_height();
         let round = aggregated_vote.get_round();
         let qc_type = if aggregated_vote.is_prevote_qc() {

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1086,8 +1086,6 @@ where
                             .await?;
                         return Ok(());
                     }
-                } else {
-                    return Err(ConsensusError::Other("Empty qc".to_string()));
                 }
 
                 // Save wal with the lastest lock.
@@ -1130,8 +1128,6 @@ where
                         .await?;
                     return Ok(());
                 }
-            } else {
-                return Err(ConsensusError::Other("empty qc".to_string()));
             }
 
             info!(


### PR DESCRIPTION
This PR does:
* overlord broadcast empty vote and qc
* state will handle signed votes with the current round