### PR TITLE
chore: update moodyblues sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = { version = "0.3", features = [ "async-await" ] }
 futures-timer = "3.0"
 hex = "0.4"
 log = "0.4"
-moodyblues-sdk = "0.2"
+moodyblues-sdk = "0.3"
 parking_lot = "0.10"
 prime_tools = "0.2"
 rand_core = "0.5"

--- a/src/smr/tests/precommit_test.rs
+++ b/src/smr/tests/precommit_test.rs
@@ -89,6 +89,8 @@ async fn test_precommit_trigger() {
             round:         1u64,
             lock_round:    Some(0),
             lock_proposal: Some(hash.clone()),
+            new_interval:  None,
+            new_config:    None,
         },
         None,
         Some((0, hash)),

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -359,7 +359,7 @@ where
         self.round = INIT_ROUND;
         info!("Overlord: state goto new height {}", self.height);
 
-        trace::start_epoch(new_height);
+        trace::start_block(new_height);
 
         // Update height and authority list.
         self.height_start = Instant::now();


### PR DESCRIPTION
This PR does:
* update moodyblues sdk version v0.2 -> v0.3