### PR TITLE
fix(SMR): handle precommit process

### DIFF
--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -435,7 +435,6 @@ impl StateMachine {
         }
 
         self.check()?;
-        self.check_polc(precommit_hash.clone(), precommit_round)?;
         self.throw_event(SMREvent::Commit(precommit_hash))?;
         self.goto_step(Step::Commit);
         Ok(())
@@ -452,22 +451,22 @@ impl StateMachine {
         Ok(())
     }
 
-    // Check PoLC when triggered precommit QC by state. If the block hash of the QC is equal to self
-    // lock, change self round and do commit, otherwise, it may be fork.
-    fn check_polc(&mut self, hash: Hash, round: u64) -> ConsensusResult<()> {
-        if let Some(lock) = self.lock.as_mut() {
-            if lock.hash != hash {
-                return Err(ConsensusError::CorrectnessErr("Fork".to_string()));
-            } else {
-                lock.round = round;
-            }
-        } else {
-            self.lock = Some(Lock { hash, round });
-        }
+    // // Check PoLC when triggered precommit QC by state. If the block hash of the QC is equal to
+    // self // lock, change self round and do commit, otherwise, it may be fork.
+    // fn check_polc(&mut self, hash: Hash, round: u64) -> ConsensusResult<()> {
+    //     if let Some(lock) = self.lock.as_mut() {
+    //         if lock.hash != hash {
+    //             return Err(ConsensusError::CorrectnessErr("Fork".to_string()));
+    //         } else {
+    //             lock.round = round;
+    //         }
+    //     } else {
+    //         self.lock = Some(Lock { hash, round });
+    //     }
 
-        self.round = round;
-        Ok(())
-    }
+    //     self.round = round;
+    //     Ok(())
+    // }
 
     /// Goto new height and clear everything.
     fn goto_new_height(&mut self, height: u64) {

--- a/src/smr/tests/precommit_test.rs
+++ b/src/smr/tests/precommit_test.rs
@@ -9,18 +9,6 @@ async fn test_precommit_trigger() {
     let mut index = 1;
     let mut test_cases: Vec<StateMachineTestCase> = Vec::new();
 
-    // Test case 01:
-    //      self proposal is not empty and not lock, precommit is not nil.
-    // The output should be commit to the precommit hash.
-    let hash = gen_hash();
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(0, Step::Precommit, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
-        SMREvent::Commit(hash.clone()),
-        None,
-        Some((0, hash)),
-    ));
-
     // Test case 02:
     //      self proposal is not empty and not lock, precommit is nil.
     // The output should be new round info without lock.
@@ -109,18 +97,6 @@ async fn test_precommit_trigger() {
         InnerState::new(0, Step::Precommit, Hash::new(), Some(lock)),
         SMRTrigger::new(hash_new.clone(), TriggerType::PrecommitQC, Some(0), 0),
         SMREvent::Commit(hash_new.clone()),
-        Some(ConsensusError::CorrectnessErr("Fork".to_string())),
-        Some((0, hash_new)),
-    ));
-
-    // Test case 07:
-    //      self proposal is not empty and without lock, precommit is not nil.
-    // This is an incorrect situation, the process can not pass self check.
-    let hash = gen_hash();
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(0, Step::Precommit, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrecommitQC, Some(0), 0),
-        SMREvent::Commit(hash.clone()),
         None,
         Some((0, hash)),
     ));
@@ -157,21 +133,6 @@ async fn test_precommit_trigger() {
     //     Some(ConsensusError::RoundDiff { local: 1, vote: 0 }),
     //     Some((0, hash)),
     // ));
-
-    // Test case 11:
-    //      self proposal is not empty and with a lock, precommit is not nil. However, precommit
-    //      hash is not equal to self lock hash.
-    // This is extremely dangerous because it can lead to fork. The process will return
-    // correctness err.
-    let hash = gen_hash();
-    let lock = Lock::new(0, hash.clone());
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(0, Step::Precommit, hash.clone(), Some(lock)),
-        SMRTrigger::new(gen_hash(), TriggerType::PrecommitQC, Some(0), 0),
-        SMREvent::Commit(hash.clone()),
-        Some(ConsensusError::CorrectnessErr("Fork".to_string())),
-        Some((0, hash)),
-    ));
 
     for case in test_cases.into_iter() {
         println!("Precommit test {}/9", index);


### PR DESCRIPTION
This PR does:
fix handle precommit process: 
* if it is from timer, goto brake step,
* else if it is empty qc, go to next round,
* else do commit directly.
