### PR TITLE
fix(consensus): fix error might block consensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Cargo.lock
 **/*.rs.bk
 
 /tests/integration_tests/test.json
+
+# IDEA IDE
+.idea

--- a/src/state/collection.rs
+++ b/src/state/collection.rs
@@ -429,7 +429,7 @@ impl Votes {
             // the addr somehow has already inserted a Vote we ignore the incoming SignedVote no
             // matter it duplicates or differs(byzantine), reject the current request!
             let exist = self.by_address.get(&addr).unwrap().clone();
-            if !vote.vote.block_hash.eq(&exist.vote.block_hash) {
+            if vote.vote.block_hash != exist.vote.block_hash {
                 // this is a byzantine behaviour
                 log::error!("Overlord: VoteCollector detects byzantine behaviour: existing: {}, signed vote inserting: {}",
                 exist,vote);

--- a/src/state/collection.rs
+++ b/src/state/collection.rs
@@ -425,6 +425,18 @@ impl Votes {
     }
 
     fn insert(&mut self, hash: Hash, addr: Address, vote: SignedVote) {
+        if self.by_address.contains_key(&addr) {
+            // the addr somehow has already inserted a Vote we ignore the incoming SignedVote no
+            // matter it duplicates or differs(byzantine), reject the current request!
+            let exist = self.by_address.get(&addr).unwrap().clone();
+            if !vote.vote.block_hash.eq(&exist.vote.block_hash) {
+                // this is a byzantine behaviour
+                log::error!("Overlord: VoteCollector detects byzantine behaviour: existing: {}, signed vote inserting: {}",
+                exist,vote);
+            }
+            return;
+        }
+
         self.by_hash
             .entry(hash)
             .or_insert_with(HashSet::new)

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -621,7 +621,7 @@ where
         })?;
 
         self.check_block(ctx, hash, block).await;
-        self.vote_process(VoteType::Prevote).await?;
+        // self.vote_process(VoteType::Prevote).await?;
         Ok(())
     }
 
@@ -864,7 +864,7 @@ where
 
         let proof = Proof {
             height,
-            round: self.round,
+            round: qc.round,
             block_hash: hash.clone(),
             signature: qc.signature.clone(),
         };


### PR DESCRIPTION
fix: reject more than one prevote or precommit for one validator in same height and same round, concern it as byzantine
fix: now prevote event will be handled only once
fix: now proof will be saved correctly