### PR TITLE
feat: parallelize verify signature before handle message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ hasher = { version = "0.1", features = ['hash-keccak'] }
 lazy_static = "1.4"
 lru-cache = "0.1"
 rand = "0.7"
+serde_json = "1.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ futures = { version = "0.3", features = [ "async-await" ] }
 futures-timer = "3.0"
 hex = "0.4"
 log = "0.4"
-moodyblues-sdk = "0.3"
 muta-apm = "0.1.0-alpha.15"
 parking_lot = "0.10"
 prime_tools = "0.2"
@@ -32,7 +31,6 @@ rand_pcg = "0.2"
 rlp = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
-serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"]}
 
 [dev-dependencies]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! able to meets most of the real business needs.
 
 #![deny(missing_docs)]
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 #![feature(test, result_map_or_else)]
 
 /// A module that impl rlp encodable and decodable trait for types that need to save wal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![deny(missing_docs)]
 #![recursion_limit = "256"]
-#![feature(test)]
+#![feature(test, result_map_or_else)]
 
 /// A module that impl rlp encodable and decodable trait for types that need to save wal.
 mod codec;

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -61,6 +61,7 @@ where
         let (mut smr_provider, evt_state, evt_timer) = SMR::new();
         let smr_handler = smr_provider.take_smr();
         let timer = Timer::new(evt_timer, smr_handler.clone(), interval, timer_config);
+        let (verify_sig_tx, verify_sig_rx) = unbounded();
 
         let (rx, mut state, resp) = {
             let mut state_rx = self.state_rx.write();
@@ -76,6 +77,7 @@ where
                 address.take().unwrap(),
                 interval,
                 authority_list,
+                verify_sig_tx,
                 consensus.take().unwrap(),
                 crypto.take().unwrap(),
                 wal.take().unwrap(),
@@ -100,7 +102,7 @@ where
         timer.run();
 
         // Run state.
-        state.run(rx, evt_state, resp).await;
+        state.run(rx, evt_state, resp, verify_sig_rx).await;
 
         Ok(())
     }

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -5,7 +5,6 @@ use derive_more::Display;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::stream::Stream;
 use log::{debug, info};
-use moodyblues_sdk::trace;
 
 use crate::smr::smr_types::{
     FromWhere, Lock, SMREvent, SMRStatus, SMRTrigger, Step, TriggerSource, TriggerType,
@@ -465,7 +464,6 @@ impl StateMachine {
         info!("Overlord: SMR goto new height: {}", height);
         self.height = height;
         self.round = INIT_ROUND;
-        trace::start_step((Step::Propose).to_string(), self.round, height);
         self.goto_step(Step::Propose);
         self.block_hash = Hash::new();
         self.lock = None;
@@ -521,7 +519,6 @@ impl StateMachine {
     #[inline]
     fn goto_step(&mut self, step: Step) {
         debug!("Overlord: SMR goto step {:?}", step);
-        trace::start_step(step.clone().to_string(), self.round, self.height);
         self.step = step;
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,6 @@
 ///
 mod collection;
 ///
+mod parallel;
+///
 pub mod process;

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -89,10 +89,6 @@ pub async fn parallel_verify<T: Codec + 'static, C: Crypto + Sync + 'static>(
                     )
             }
 
-            OverlordMsg::RichStatus(_) => {
-                let _ = tx.unbounded_send((ctx, msg_clone));
-            }
-
             _ => (),
         }
     });

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -128,13 +128,3 @@ fn verify_qc<T: Codec, C: Crypto>(
             );
     }
 }
-
-// pub fn verify_signature<C: Crypto>(
-//     crypto: Arc<C>,
-//     sig: Signature,
-//     addr: Address,
-//     bytes: Vec<u8>,
-// ) -> bool {
-//     let hash = crypto.hash(Bytes::from(bytes));
-//     crypto.verify_signature(sig, hash, addr).is_ok()
-// }

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -72,7 +72,7 @@ pub async fn parallel_verify<T: Codec + 'static, C: Crypto + Sync + 'static>(
             }
 
             OverlordMsg::SignedChoke(sc) => {
-                let hash = crypto.hash(Bytes::from(rlp::encode(&sc.choke)));
+                let hash = crypto.hash(Bytes::from(rlp::encode(&sc.choke.to_hash())));
                 crypto
                     .verify_signature(sc.signature.clone(), hash, sc.address.clone())
                     .map_or_else(

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use creep::Context;
+use futures::channel::mpsc::UnboundedSender;
+
+use crate::types::{Address, AggregatedVote, OverlordMsg, Signature};
+use crate::utils::auth_manage::AuthorityManage;
+use crate::{Codec, ConsensusResult, Crypto};
+
+pub async fn parallel_verify<T: Codec + 'static, C: Crypto + Sync + 'static>(
+    ctx: Context,
+    msg: OverlordMsg<T>,
+    crypto: Arc<C>,
+    authority: AuthorityManage,
+    tx: UnboundedSender<(Context, OverlordMsg<T>)>,
+) {
+    let msg_clone = msg.clone();
+    tokio::spawn(async move {
+        match msg {
+            OverlordMsg::SignedProposal(sp) => {
+                let hash = crypto.hash(Bytes::from(rlp::encode(&sp.proposal)));
+                if let Err(err) = crypto.verify_signature(
+                    sp.signature.clone(),
+                    hash,
+                    sp.proposal.proposer.clone(),
+                ) {
+                    log::error!(
+                        "Overlord: verify {:?} proposal signature failed {:?}",
+                        sp,
+                        err
+                    );
+                    return;
+                }
+
+                if let Some(polc) = sp.proposal.lock {
+                    verify_qc(
+                        ctx.clone(),
+                        crypto,
+                        polc.lock_votes,
+                        authority,
+                        tx.clone(),
+                        msg_clone.clone(),
+                    );
+                } else {
+                    let _ = tx.unbounded_send((ctx, msg_clone));
+                }
+            }
+
+            OverlordMsg::SignedVote(sv) => {
+                let hash = crypto.hash(Bytes::from(rlp::encode(&sv.vote)));
+                crypto
+                    .verify_signature(sv.signature.clone(), hash, sv.voter.clone())
+                    .map_or_else(
+                        |err| {
+                            log::error!(
+                                "Overlord: verify {:?} vote signature failed {:?}",
+                                sv,
+                                err
+                            );
+                        },
+                        |_| {
+                            let _ = tx.unbounded_send((ctx, msg_clone));
+                        },
+                    );
+            }
+
+            OverlordMsg::AggregatedVote(qc) => {
+                verify_qc(ctx, crypto, qc, authority, tx, msg_clone);
+            }
+
+            OverlordMsg::SignedChoke(sc) => {
+                let hash = crypto.hash(Bytes::from(rlp::encode(&sc.choke)));
+                crypto
+                    .verify_signature(sc.signature.clone(), hash, sc.address.clone())
+                    .map_or_else(
+                        |err| {
+                            log::error!(
+                                "Overlord: verify {:?} choke signature failed {:?}",
+                                sc,
+                                err
+                            );
+                        },
+                        |_| {
+                            let _ = tx.unbounded_send((ctx, msg_clone));
+                        },
+                    )
+            }
+
+            OverlordMsg::RichStatus(_) => {
+                let _ = tx.unbounded_send((ctx, msg_clone));
+            }
+
+            _ => (),
+        }
+    });
+}
+
+fn get_voters(
+    addr_bitmap: &Bytes,
+    authority_manage: AuthorityManage,
+) -> ConsensusResult<Vec<Address>> {
+    authority_manage.is_above_threshold(&addr_bitmap)?;
+    authority_manage.get_voters(&addr_bitmap)
+}
+
+fn verify_qc<T: Codec, C: Crypto>(
+    ctx: Context,
+    crypto: Arc<C>,
+    qc: AggregatedVote,
+    authority: AuthorityManage,
+    tx: UnboundedSender<(Context, OverlordMsg<T>)>,
+    msg_clone: OverlordMsg<T>,
+) {
+    let hash = crypto.hash(Bytes::from(rlp::encode(&qc.to_vote())));
+    if let Ok(voters) = get_voters(&qc.signature.address_bitmap, authority) {
+        crypto
+            .verify_aggregated_signature(qc.signature.signature.clone(), hash, voters)
+            .map_or_else(
+                |err| {
+                    log::error!(
+                        "Overlord: verify {:?} aggregated signature error {:?}",
+                        qc,
+                        err
+                    );
+                },
+                |_| {
+                    let _ = tx.unbounded_send((ctx, msg_clone));
+                },
+            );
+    }
+}
+
+pub fn verify_signature<C: Crypto>(
+    crypto: Arc<C>,
+    sig: Signature,
+    addr: Address,
+    bytes: Vec<u8>,
+) -> bool {
+    let hash = crypto.hash(Bytes::from(bytes));
+    crypto.verify_signature(sig, hash, addr).is_ok()
+}

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -3,11 +3,13 @@ use std::sync::Arc;
 use bytes::Bytes;
 use creep::Context;
 use futures::channel::mpsc::UnboundedSender;
+use muta_apm::derive::tracing_span;
 
 use crate::types::{Address, AggregatedVote, OverlordMsg, Signature};
 use crate::utils::auth_manage::AuthorityManage;
 use crate::{Codec, ConsensusResult, Crypto};
 
+#[tracing_span(kind = "overlord.vreify_sig_pool")]
 pub async fn parallel_verify<T: Codec + 'static, C: Crypto + Sync + 'static>(
     ctx: Context,
     msg: OverlordMsg<T>,

--- a/src/state/parallel.rs
+++ b/src/state/parallel.rs
@@ -5,7 +5,7 @@ use creep::Context;
 use futures::channel::mpsc::UnboundedSender;
 use muta_apm::derive::tracing_span;
 
-use crate::types::{Address, AggregatedVote, OverlordMsg, Signature};
+use crate::types::{Address, AggregatedVote, OverlordMsg};
 use crate::utils::auth_manage::AuthorityManage;
 use crate::{Codec, ConsensusResult, Crypto};
 
@@ -133,12 +133,12 @@ fn verify_qc<T: Codec, C: Crypto>(
     }
 }
 
-pub fn verify_signature<C: Crypto>(
-    crypto: Arc<C>,
-    sig: Signature,
-    addr: Address,
-    bytes: Vec<u8>,
-) -> bool {
-    let hash = crypto.hash(Bytes::from(bytes));
-    crypto.verify_signature(sig, hash, addr).is_ok()
-}
+// pub fn verify_signature<C: Crypto>(
+//     crypto: Arc<C>,
+//     sig: Signature,
+//     addr: Address,
+//     bytes: Vec<u8>,
+// ) -> bool {
+//     let hash = crypto.hash(Bytes::from(bytes));
+//     crypto.verify_signature(sig, hash, addr).is_ok()
+// }

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1821,26 +1821,3 @@ fn mock_init_qc() -> AggregatedVote {
         leader:     Address::default(),
     }
 }
-
-#[cfg(test)]
-mod test {
-    use std::time::Duration;
-
-    use log::info;
-    use serde_json::json;
-
-    #[test]
-    fn test_json() {
-        let tmp = Duration::from_millis(200);
-        let cost = tmp.as_millis() as u64;
-
-        info!(
-            "{:?}",
-            json!({
-                "height": 1u64,
-                "consensus_round": 1u64,
-                "consume": cost,
-            })
-        );
-    }
-}

--- a/src/types.rs
+++ b/src/types.rs
@@ -132,6 +132,17 @@ impl<T: Codec> OverlordMsg<T> {
             _ => false,
         }
     }
+
+    pub(crate) fn get_height(&self) -> u64 {
+        match self {
+            OverlordMsg::SignedProposal(sp) => sp.proposal.height,
+            OverlordMsg::SignedVote(sv) => sv.get_height(),
+            OverlordMsg::AggregatedVote(av) => av.get_height(),
+            OverlordMsg::RichStatus(s) => s.height,
+            OverlordMsg::SignedChoke(sc) => sc.choke.height,
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// How does state goto the current round.


### PR DESCRIPTION
This PR does:
1. Add a `parallel_verify` layer as a `verify_signature_pool`. On receiving message, send the message to the verify pool. The layer will send the result to state to handle it.
2. Refactor save vote with the context.