### PR TITLE
fix: verify proposer before filter proposal

### DIFF
--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -587,6 +587,13 @@ where
             hex::encode(signed_proposal.proposal.block_hash.clone())
         );
 
+        // Verify proposer before filter proposal.
+        self.verify_proposer(
+            proposal_height,
+            proposal_round,
+            &signed_proposal.proposal.proposer,
+        )?;
+
         if self.filter_signed_proposal(
             ctx.clone(),
             proposal_height,
@@ -596,10 +603,8 @@ where
             return Ok(());
         }
 
-        //  Verify proposal signature.
         let proposal = signed_proposal.proposal.clone();
         let signature = signed_proposal.signature.clone();
-        self.verify_proposer(proposal_height, proposal_round, &proposal.proposer)?;
 
         // If the signed proposal is with a lock, check the lock round and the QC then trigger it to
         // SMR. Otherwise, touch off SMR directly.


### PR DESCRIPTION
This PR does:
* Move verify proposer in front of filter proposal. So that all of the proposals will be verified before inserted to the collector.