### PR TITLE
refactor(wal): handle wal lost condition

### DIFF
--- a/examples/salon.rs
+++ b/examples/salon.rs
@@ -331,7 +331,7 @@ impl Speaker {
         });
 
         self.overlord
-            .run(interval, speaker_list, timer_config)
+            .run(0, interval, speaker_list, timer_config)
             .await
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use crate::error::ConsensusError;
 use crate::types::{Address, Commit, Hash, Node, OverlordMsg, Signature, Status, ViewChangeReason};
 
 /// Overlord consensus result.
-pub type ConsensusResult<T> = ::std::result::Result<T, ConsensusError>;
+pub type ConsensusResult<T> = std::result::Result<T, ConsensusError>;
 
 const INIT_HEIGHT: u64 = 0;
 const INIT_ROUND: u64 = 0;

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -54,6 +54,7 @@ where
     /// Run overlord consensus process. The `interval` is the height interval as millisecond.
     pub async fn run(
         &self,
+        init_height: u64,
         interval: u64,
         authority_list: Vec<Node>,
         timer_config: Option<DurationConfig>,
@@ -75,6 +76,7 @@ where
             let (tmp_state, tmp_resp) = State::new(
                 smr_handler,
                 address.take().unwrap(),
+                init_height,
                 interval,
                 authority_list,
                 verify_sig_tx,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1648,6 +1648,12 @@ where
     }
 
     fn wal_lost(&mut self) -> ConsensusResult<()> {
+        if !self.authority.contains(&self.address) {
+            return Ok(());
+        }
+
+        // Set consensus power.
+        self.consensus_power = true;
         let smr_base = SMRBase {
             height: self.height,
             round:  self.round,
@@ -1680,7 +1686,6 @@ where
         info!("overlord: start from wal {}", wal_info);
 
         // recover basic state
-        self.consensus_power = true;
         self.height = wal_info.height;
         self.round = wal_info.round;
         self.is_leader = self.is_proposer()?;

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1672,7 +1672,7 @@ where
         } else {
             return Ok(());
         }
-        
+
         let wal_info = self.load_wal().await?;
         if wal_info.is_none() {
             if self.height != INIT_HEIGHT {

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -89,6 +89,7 @@ where
             height:              init_height,
             round:               INIT_ROUND,
             state_machine:       smr,
+            consensus_power:     auth.contains(&addr),
             address:             addr,
             proposals:           ProposalCollector::new(),
             votes:               VoteCollector::new(),
@@ -101,7 +102,6 @@ where
             update_from_where:   UpdateFrom::PrecommitQC(mock_init_qc()),
             height_start:        Instant::now(),
             block_interval:      interval,
-            consensus_power:     false,
             stopped:             false,
 
             verify_sig_tx: verify_tx,
@@ -1667,9 +1667,7 @@ where
     }
 
     async fn start_with_wal(&mut self) -> ConsensusResult<()> {
-        if self.authority.contains(&self.address) {
-            self.consensus_power = true;
-        } else {
+        if !self.consensus_power {
             return Ok(());
         }
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1648,12 +1648,6 @@ where
     }
 
     fn wal_lost(&mut self) -> ConsensusResult<()> {
-        if !self.authority.contains(&self.address) {
-            return Ok(());
-        }
-
-        // Set consensus power.
-        self.consensus_power = true;
         let smr_base = SMRBase {
             height: self.height,
             round:  self.round,
@@ -1673,6 +1667,11 @@ where
     }
 
     async fn start_with_wal(&mut self) -> ConsensusResult<()> {
+        if !self.authority.contains(&self.address) {
+            return Ok(());
+        }
+
+        self.consensus_power = true;
         let wal_info = self.load_wal().await?;
         if wal_info.is_none() {
             if self.height != INIT_HEIGHT {

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1667,11 +1667,12 @@ where
     }
 
     async fn start_with_wal(&mut self) -> ConsensusResult<()> {
-        if !self.authority.contains(&self.address) {
+        if self.authority.contains(&self.address) {
+            self.consensus_power = true;
+        } else {
             return Ok(());
         }
-
-        self.consensus_power = true;
+        
         let wal_info = self.load_wal().await?;
         if wal_info.is_none() {
             if self.height != INIT_HEIGHT {

--- a/tests/integration_tests/primitive.rs
+++ b/tests/integration_tests/primitive.rs
@@ -270,7 +270,7 @@ impl Participant {
         });
 
         self.overlord
-            .run(0, interval, node_list, timer_config)
+            .run(1, interval, node_list, timer_config)
             .await
             .unwrap();
 

--- a/tests/integration_tests/primitive.rs
+++ b/tests/integration_tests/primitive.rs
@@ -270,7 +270,7 @@ impl Participant {
         });
 
         self.overlord
-            .run(interval, node_list, timer_config)
+            .run(0, interval, node_list, timer_config)
             .await
             .unwrap();
 


### PR DESCRIPTION
This PR does:
Handle wal lost condition. State will mock a wal info to SMR, and go on running.