### PR TITLE
fix: the cfg macro in get leader api

### DIFF
--- a/src/utils/auth_manage.rs
+++ b/src/utils/auth_manage.rs
@@ -168,7 +168,7 @@ pub fn get_leader(height: u64, round: u64, mut authority_list: Vec<Node>) -> Add
         propose_weights.push(node.propose_weight as u64);
     }
 
-    let index = if cfg!(features = "random_leader") {
+    let index = if cfg!(feature = "random_leader") {
         get_random_proposer_index(height + round, &propose_weights, weight_sum as u64)
     } else {
         rotation_leader_index(height, round, authority_list.len())


### PR DESCRIPTION
Fix the `cfg!` macro in `get_leader` API. This change has nothing to do with stability.