### PR TITLE
fix(process): the start of block interval

### DIFF
--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -602,6 +602,8 @@ where
             &signed_proposal.proposal.proposer,
         )?;
 
+        self.height_start = Instant::now();
+
         if self.filter_signed_proposal(
             ctx.clone(),
             proposal_height,


### PR DESCRIPTION
fix https://github.com/nervosnetwork/overlord/issues/140

Followers will rewrite `height_start` when handle_signed_proposal, so the cost of followers will not include the time leader sleep.

set block interval 10s:
65 "timestamp": "2022-07-11 08:49:21 +00:00"
66 "timestamp": "2022-07-11 08:49:32 +00:00"
67 "timestamp": "2022-07-11 08:49:42 +00:00"
68 "timestamp": "2022-07-11 08:49:53 +00:00"

Looks good.